### PR TITLE
docs: Fix error in example for incrementBuild

### DIFF
--- a/packages/website/docs/configuration-tool.md
+++ b/packages/website/docs/configuration-tool.md
@@ -384,7 +384,7 @@ platforms:
   ios:
     targets:
       App:
-        incrementBuildNumber: true
+        incrementBuild: true
 ```
 
 ### `bundleId`


### PR DESCRIPTION
Simple documentation typo fix:
On the website, the `incrementBuild` command is written correctly in the heading, but wrong in the code example.