### PR TITLE
Allow multiple operations to transform a single file

### DIFF
--- a/packages/configure/test/ops/android.xml.test.ts
+++ b/packages/configure/test/ops/android.xml.test.ts
@@ -118,6 +118,46 @@ describe('op: android.xml', () => {
     `.trim());
   });
 
+  it('should delete root and replace', async () => {
+    let op: AndroidXmlOperation = makeOp('android', 'xml', [
+      {
+        file: 'app/src/main/AndroidManifest.xml',
+        delete: '/manifest'
+      },
+    ]);
+
+    await Op(ctx, op as Operation);
+
+    let data = ctx.project.android?.getXmlFile('app/src/main/AndroidManifest.xml');
+
+    console.log(data!.getDocumentElement());
+
+    op = makeOp('android', 'xml', [
+      {
+        file: 'app/src/main/AndroidManifest.xml',
+        target: '/',
+        inject: `<tag><thing /></tag>`
+      },
+    ]);
+
+    data = ctx.project.android?.getXmlFile('app/src/main/AndroidManifest.xml');
+
+    console.log(data!.getDocumentElement());
+
+    await Op(ctx, op as Operation);
+
+    await ctx.project.commit();
+
+    const file = await readFile(join(dir, 'android/app/src/main/AndroidManifest.xml'), { encoding: 'utf-8' });
+    //console.log(file);
+    expect(file.trim()).toBe(`
+<?xml version="1.0" encoding="utf-8" ?>
+<tag>
+    <thing />
+</tag>
+    `.trim());
+  });
+
   // per https://github.com/ionic-team/trapeze/issues/87
   it('should merge nodes', async () => {
     const op: AndroidXmlOperation = makeOp('android', 'xml', [

--- a/packages/configure/test/ops/android.xml.test.ts
+++ b/packages/configure/test/ops/android.xml.test.ts
@@ -158,6 +158,50 @@ describe('op: android.xml', () => {
     `.trim());
   });
 
+
+  it('should process multiple replaces', async () => {
+    let op: AndroidXmlOperation = makeOp('android', 'xml', [
+      {
+        resFile: 'values/strings.xml',
+        target: 'resources/string[@name="app_name"]',
+        replace: '<string name="app_name">$PRODUCT_NAME</string>'
+      },
+      {
+        resFile: 'values/strings.xml',
+        target: 'resources/string[@name="title_activity_main"]',
+        replace: '<string name="title_activity_main">$PRODUCT_NAME</string>'
+      },
+      {
+        resFile: 'values/strings.xml',
+        target: 'resources/string[@name="package_name"]',
+        replace: '<string name="package_name">$ANDROID_PACKAGE_NAME</string>'
+      },
+      {
+        resFile: 'values/strings.xml',
+        target: 'resources/string[@name="custom_url_scheme"]',
+        replace: '<string name="custom_url_scheme">$ANDROID_PACKAGE_NAME</string>'
+      },
+    ]);
+
+    await Op(ctx, op as Operation);
+
+    let data = ctx.project.android?.getResourceXmlFile('values/strings.xml');
+
+    await ctx.project.commit();
+
+    const file = await readFile(join(dir, 'android/app/src/main/res/values/strings.xml'), { encoding: 'utf-8' });
+    //console.log(file);
+    expect(file.trim()).toBe(`
+<?xml version='1.0' encoding='utf-8' ?>
+<resources>
+    <string name="app_name">$PRODUCT_NAME</string>
+    <string name="title_activity_main">$PRODUCT_NAME</string>
+    <string name="package_name">$ANDROID_PACKAGE_NAME</string>
+    <string name="custom_url_scheme">$ANDROID_PACKAGE_NAME</string>
+</resources>
+    `.trim());
+  });
+
   // per https://github.com/ionic-team/trapeze/issues/87
   it('should merge nodes', async () => {
     const op: AndroidXmlOperation = makeOp('android', 'xml', [

--- a/packages/configure/test/ops/android.xml.test.ts
+++ b/packages/configure/test/ops/android.xml.test.ts
@@ -130,7 +130,8 @@ describe('op: android.xml', () => {
 
     let data = ctx.project.android?.getXmlFile('app/src/main/AndroidManifest.xml');
 
-    console.log(data!.getDocumentElement());
+    // The document element should be null at this point as we deleted the root node
+    expect(data!.getDocumentElement()).toBeNull();
 
     op = makeOp('android', 'xml', [
       {
@@ -140,11 +141,10 @@ describe('op: android.xml', () => {
       },
     ]);
 
-    data = ctx.project.android?.getXmlFile('app/src/main/AndroidManifest.xml');
-
-    console.log(data!.getDocumentElement());
-
     await Op(ctx, op as Operation);
+
+    // The document element should be null at this point as we deleted the root node
+    expect(data!.getDocumentElement()).not.toBeNull();
 
     await ctx.project.commit();
 

--- a/packages/project/src/json.ts
+++ b/packages/project/src/json.ts
@@ -15,6 +15,10 @@ export class JsonFile extends VFSStorable {
   }
 
   async load() {
+    if (this.vfs.isOpen(this.path)) {
+      return;
+    }
+
     this.json = await readJson(this.path);
     this.vfs.open(this.path, this, this.commitFn, this.diffFn);
   }

--- a/packages/project/src/plist.ts
+++ b/packages/project/src/plist.ts
@@ -21,6 +21,10 @@ export class PlistFile extends VFSStorable {
   }
 
   async load() {
+    if (this.vfs.isOpen(this.path)) {
+      return;
+    }
+
     this.doc = await parsePlist(this.path);
     this.vfs.open(this.path, this, this.plistCommitFn, this.plistDiffFn);
   }

--- a/packages/project/src/properties.ts
+++ b/packages/project/src/properties.ts
@@ -49,6 +49,10 @@ export class PropertiesFile extends VFSStorable {
   }
 
   async load() {
+    if (this.vfs.isOpen(this.path)) {
+      return;
+    }
+
     if (!await pathExists(this.path)) {
       throw new Error(`Unable to locate file at ${this.path}`);
     }

--- a/packages/project/src/vfs.ts
+++ b/packages/project/src/vfs.ts
@@ -82,6 +82,10 @@ export class VFS {
     return this.openFiles[filename] ?? null;
   }
 
+  isOpen(filename: string) {
+    return !!this.get(filename);
+  }
+
   all() {
     return Object.keys(this.openFiles).reduce((files, fname) => {
       files[fname] = this.openFiles[fname];

--- a/packages/project/src/xml.ts
+++ b/packages/project/src/xml.ts
@@ -19,7 +19,7 @@ export class XmlFile extends VFSStorable {
 
   async load() {
     // Don't load the file if it's already open
-    if (!!this.vfs.get(this.path)) {
+    if (this.vfs.isOpen(this.path)) {
       return;
     }
 

--- a/packages/project/src/xml.ts
+++ b/packages/project/src/xml.ts
@@ -18,6 +18,11 @@ export class XmlFile extends VFSStorable {
   }
 
   async load() {
+    // Don't load the file if it's already open
+    if (!!this.vfs.get(this.path)) {
+      return;
+    }
+
     this.doc = await parseXml(this.path);
     this.vfs.open(this.path, this, this.xmlCommitFn, this.xmlDiffFn);
 

--- a/packages/project/test/xml-file.test.ts
+++ b/packages/project/test/xml-file.test.ts
@@ -70,11 +70,10 @@ describe('xml file', () => {
 
   it('Should delete and replace root', async () => {
     file.deleteNodes('/resources');
-    file.injectFragment('/', `<tag><thing /></tag>`);
+    file.injectFragment('/', `<tag><thing/></tag>`);
     const doc = file.getDocumentElement();
-    console.log(doc);
     const serialized = serializeXml(doc);
-    expect(serialized).toBe(`<tag><thing /></tag>`);
+    expect(serialized).toBe(`<tag><thing/></tag>`);
   });
 
   it('Should inject', async () => {

--- a/packages/project/test/xml-file.test.ts
+++ b/packages/project/test/xml-file.test.ts
@@ -68,6 +68,15 @@ describe('xml file', () => {
     `.trim());
   });
 
+  it('Should delete and replace root', async () => {
+    file.deleteNodes('/resources');
+    file.injectFragment('/', `<tag><thing /></tag>`);
+    const doc = file.getDocumentElement();
+    console.log(doc);
+    const serialized = serializeXml(doc);
+    expect(serialized).toBe(`<tag><thing /></tag>`);
+  });
+
   it('Should inject', async () => {
     const doc = file.getDocumentElement();
     const node = file.find('resources');


### PR DESCRIPTION
This fixes some of the issues in #87. Files were being reloaded on each operation so having two in a row wouldn't apply those two operations, which was not what people expected. This resolves that and also adds more tests