### PR TITLE
fix #96: Env var JSON parsing error

### DIFF
--- a/packages/configure/src/ctx.ts
+++ b/packages/configure/src/ctx.ts
@@ -102,15 +102,18 @@ export function initVarsFromEnv(ctx: Context, vars: Variables) {
   }
 
   for (const v in vars) {
+    let existing = process.env[v];
     try {
-      const existing = process.env[v] && JSON.parse(process.env[v]!);
+      existing = existing && JSON.parse(existing!);
+    } catch (e) {
+      console.log(`Unable to parse environment variable ${v} as JSON`, e);
+      console.log('Using regular string value instead');
+    } finally {
       if (existing) {
         ctx.vars[v] = {
           value: existing,
         };
       }
-    } catch (e) {
-      console.log(`Unable to parse environment variable ${v}`, e);
     }
   }
 }


### PR DESCRIPTION
- create a configuration file with a non-defaulted var `SOME_VERSION`, used as `versionName` from android for example
- run `SOME_VERSION="1.2.3" npx trapeze`
- [ ] no error should pop in the console, and you should not be prompted for a value for `SOME_VERSION`
- [ ] everything should work as before when using JSON formatted vars also