### PR TITLE
fix: save parent to variable before losing it

### DIFF
--- a/packages/project/src/xml.ts
+++ b/packages/project/src/xml.ts
@@ -196,10 +196,11 @@ export class XmlFile extends VFSStorable {
     nodes.forEach(n => {
       const index = Array.prototype.indexOf.call(n.parentNode?.childNodes, n);
       if (index >= 0) {
-        n.parentNode!.removeChild(n);
-        n.parentNode!.insertBefore(
+        const parent = n.parentNode;
+        parent!.removeChild(n);
+        parent!.insertBefore(
           parsed.documentElement,
-          n.parentNode?.childNodes[index] ?? null,
+          parent?.childNodes[index] ?? null,
         );
       }
     });


### PR DESCRIPTION
@mlynch huge thanks for the [`appName` feature](https://github.com/ionic-team/trapeze/issues/123) 🚀 

However, I faced an issue in my environment, the `app_name` was not added and the script yelled at null reference before `insertBefore` method. I didn't have much time to debug it properly, but I figured, that the `parentNode` should indeed be `null` after we removed the child (**it must** lose its parent). That's how it works for me anyway.

I assume this may work differently for me and the test environment because jest uses its own implementation of the global document, since it runs without a browser (I know about [the first rule](https://blog.codinghorror.com/the-first-rule-of-programming-its-always-your-fault/) 😄, but it's the only idea I have)

---

I've also created a small repo for reproducing the bug - https://github.com/chernodub/ionic-replacefragment-issue-repro

if you run `npx trapeze run config.yml --verbose`, you'll see:
```
[warn] Unable to set appName: Cannot read properties of null (reading 'insertBefore')
```
