### PR TITLE
Use the serialized variable when writing on the properties file

### DIFF
--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ionic-team/capacitor-configure.git"
+    "url": "git+https://github.com/marioshtika/trapeze.git"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/marioshtika/trapeze.git"
+    "url": "git+https://github.com/ionic-team/capacitor-configure.git"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/project/src/util/properties.ts
+++ b/packages/project/src/util/properties.ts
@@ -8,5 +8,5 @@ export async function parseProperties(filename: string) {
 
 export async function writeProperties(filename: string, data: any) {
   const serialized = ini.stringify(data);
-  return writeFile(filename, data);
+  return writeFile(filename, serialized);
 }


### PR DESCRIPTION
Hello the issue is described in [here](https://github.com/ionic-team/trapeze/issues/198)

I am using the below code to write on the grade.properties file on Android, but it is not working

```
platforms:
  android:
    properties:
      - file: gradle.properties
        entries: 
          android.enableJetifier: true
``` 

I followed the logic and it looks like it is working but it is not writing it back to the file

I was getting the below error message
```
Fatal error: Error running command
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received [Object: null prototype]
```

And as @Ali-H888 mentioned, if you check [here](https://github.com/ionic-team/trapeze/blob/4d0a38fb9a4f95460d3de20dede3277c332361c9/packages/project/src/util/properties.ts#L11) you will find that it is passing data to the write file argument instead of the serialized string and that's what is causing the error.

We both tested the fix and it's working on our local machine.

I have created a pull request for this.