### PR TITLE
General `package.json` fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5728,7 +5728,8 @@
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -5813,6 +5814,15 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/lodash": {
       "version": "4.14.179",
@@ -23372,6 +23382,7 @@
         "cross-spawn": "^7.0.3",
         "diff": "^5.1.0",
         "env-paths": "^3.0.0",
+        "fs-extra": "^11.2.0",
         "gradle-to-js": "^2.0.0",
         "ini": "^2.0.0",
         "kleur": "^4.1.5",
@@ -23393,7 +23404,7 @@
       "devDependencies": {
         "@types/cross-spawn": "^6.0.2",
         "@types/diff": "^5.0.2",
-        "@types/fs-extra": "^9.0.13",
+        "@types/fs-extra": "^11.0.4",
         "@types/ini": "^1.3.31",
         "@types/jest": "^27.0.2",
         "@types/lodash": "^4.14.175",
@@ -23413,6 +23424,16 @@
         "prettier": ">=2.4.0"
       }
     },
+    "packages/project/node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "packages/project/node_modules/diff": {
       "version": "5.1.0",
       "license": "BSD-3-Clause",
@@ -23420,11 +23441,35 @@
         "node": ">=0.3.1"
       }
     },
+    "packages/project/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "packages/project/node_modules/ini": {
       "version": "2.0.0",
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/project/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "packages/project/node_modules/prettier": {
@@ -23438,6 +23483,14 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "packages/project/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "packages/website": {
@@ -27343,7 +27396,7 @@
         "@trapezedev/gradle-parse": "7.0.10",
         "@types/cross-spawn": "^6.0.2",
         "@types/diff": "^5.0.2",
-        "@types/fs-extra": "^9.0.13",
+        "@types/fs-extra": "^11.0.4",
         "@types/ini": "^1.3.31",
         "@types/jest": "^27.0.2",
         "@types/lodash": "^4.14.175",
@@ -27355,6 +27408,7 @@
         "cross-spawn": "^7.0.3",
         "diff": "^5.1.0",
         "env-paths": "^3.0.0",
+        "fs-extra": "^11.2.0",
         "gradle-to-js": "^2.0.0",
         "ini": "^2.0.0",
         "jest": "^27.2.5",
@@ -27385,14 +27439,48 @@
             "prettier": ">=2.4.0"
           }
         },
+        "@types/fs-extra": {
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+          "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+          "dev": true,
+          "requires": {
+            "@types/jsonfile": "*",
+            "@types/node": "*"
+          }
+        },
         "diff": {
           "version": "5.1.0"
+        },
+        "fs-extra": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
         },
         "ini": {
           "version": "2.0.0"
         },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
         "prettier": {
           "version": "2.7.1"
+        },
+        "universalify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
         }
       }
     },
@@ -27537,6 +27625,8 @@
     },
     "@types/fs-extra": {
       "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
       "requires": {
         "@types/node": "*"
       }
@@ -27614,6 +27704,15 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+    },
+    "@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/lodash": {
       "version": "4.14.179"

--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
     "node": "16.18.1",
     "npm": "9.1.2"
   },
-  "packageManager": "npm@9.1.l"
+  "packageManager": "npm@9.1.2"
 }

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -28,6 +28,7 @@
     "cross-spawn": "^7.0.3",
     "diff": "^5.1.0",
     "env-paths": "^3.0.0",
+    "fs-extra": "^11.2.0",
     "gradle-to-js": "^2.0.0",
     "ini": "^2.0.0",
     "kleur": "^4.1.5",
@@ -66,7 +67,7 @@
   "devDependencies": {
     "@types/cross-spawn": "^6.0.2",
     "@types/diff": "^5.0.2",
-    "@types/fs-extra": "^9.0.13",
+    "@types/fs-extra": "^11.0.4",
     "@types/ini": "^1.3.31",
     "@types/jest": "^27.0.2",
     "@types/lodash": "^4.14.175",


### PR DESCRIPTION
this PR includes two changes:

* repair invalid `packageManager` string in root `package.json` file, as this ended up with a letter in the SemVer string.
* add `fs-extra` to the `project` package, as this is imported into the `xml.ts` file. associated `@types` package updated to match on major version.

based on the `@types/fs-extra` that was already there, it seems like this was originally used at major version `9`. so please do let me know if upgrading to `11` turns out to be a problem.

---

executing `npm run test` in the root of the repo passed all tests. I've also installed this from a local folder path and used it successfully in a personal project to confirm.