### PR TITLE
fix: remove unused dependency npm-watch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6175,10 +6175,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "license": "ISC"
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -11714,10 +11710,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "license": "ISC"
-    },
     "node_modules/image-size": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
@@ -15646,50 +15638,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
     },
-    "node_modules/nodemon": {
-      "version": "2.0.15",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5",
-        "update-notifier": "^5.1.0"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "3.2.7",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      }
-    },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
       "license": "BSD-2-Clause",
@@ -16471,17 +16419,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/npm-watch": {
-      "version": "0.9.0",
-      "license": "MIT",
-      "dependencies": {
-        "nodemon": "^2.0.7",
-        "through2": "^4.0.2"
-      },
-      "bin": {
-        "npm-watch": "cli.js"
       }
     },
     "node_modules/nprogress": {
@@ -18038,10 +17975,6 @@
     "node_modules/psl": {
       "version": "1.8.0",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -21267,16 +21200,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/touch": {
-      "version": "3.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "nopt": "~1.0.10"
-      },
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "4.0.0",
       "dev": true,
@@ -21793,10 +21716,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "license": "MIT"
     },
     "node_modules/unherit": {
       "version": "1.1.3",
@@ -23325,7 +23244,6 @@
         "env-paths": "^3.0.0",
         "kleur": "^4.1.4",
         "lodash": "^4.17.21",
-        "npm-watch": "^0.9.0",
         "plist": "^3.0.4",
         "prompts": "^2.4.2",
         "replace": "^1.1.0",
@@ -23377,7 +23295,6 @@
         "kleur": "^4.1.5",
         "lodash": "^4.17.21",
         "mergexml": "^1.2.3",
-        "npm-watch": "^0.9.0",
         "plist": "^3.0.4",
         "prettier": "^2.7.1",
         "prompts": "^2.4.2",
@@ -27312,7 +27229,6 @@
         "jest": "^27.2.5",
         "kleur": "^4.1.4",
         "lodash": "^4.17.21",
-        "npm-watch": "^0.9.0",
         "plist": "^3.0.4",
         "prompts": "^2.4.2",
         "replace": "^1.1.0",
@@ -27361,7 +27277,6 @@
         "kleur": "^4.1.5",
         "lodash": "^4.17.21",
         "mergexml": "^1.2.3",
-        "npm-watch": "^0.9.0",
         "plist": "^3.0.4",
         "prettier": "^2.7.1",
         "prompts": "^2.4.2",
@@ -27957,9 +27872,6 @@
     "abab": {
       "version": "2.0.5",
       "dev": true
-    },
-    "abbrev": {
-      "version": "1.1.1"
     },
     "accepts": {
       "version": "1.3.8",
@@ -31735,9 +31647,6 @@
     "ignore": {
       "version": "5.2.0"
     },
-    "ignore-by-default": {
-      "version": "1.0.1"
-    },
     "image-size": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
@@ -34281,35 +34190,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
     },
-    "nodemon": {
-      "version": "2.0.15",
-      "requires": {
-        "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5",
-        "update-notifier": "^5.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "nopt": {
-      "version": "1.0.10",
-      "requires": {
-        "abbrev": "1"
-      }
-    },
     "normalize-package-data": {
       "version": "3.0.3",
       "requires": {
@@ -34836,13 +34716,6 @@
       "version": "4.0.1",
       "requires": {
         "path-key": "^3.0.0"
-      }
-    },
-    "npm-watch": {
-      "version": "0.9.0",
-      "requires": {
-        "nodemon": "^2.0.7",
-        "through2": "^4.0.2"
       }
     },
     "nprogress": {
@@ -35849,9 +35722,6 @@
     "psl": {
       "version": "1.8.0",
       "dev": true
-    },
-    "pstree.remy": {
-      "version": "1.1.8"
     },
     "pump": {
       "version": "3.0.0",
@@ -38108,12 +37978,6 @@
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
       "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g=="
     },
-    "touch": {
-      "version": "3.1.0",
-      "requires": {
-        "nopt": "~1.0.10"
-      }
-    },
     "tough-cookie": {
       "version": "4.0.0",
       "dev": true,
@@ -38412,9 +38276,6 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "undefsafe": {
-      "version": "2.0.5"
     },
     "unherit": {
       "version": "1.1.3",

--- a/packages/configure/package.json
+++ b/packages/configure/package.json
@@ -39,7 +39,6 @@
     "env-paths": "^3.0.0",
     "kleur": "^4.1.4",
     "lodash": "^4.17.21",
-    "npm-watch": "^0.9.0",
     "plist": "^3.0.4",
     "prompts": "^2.4.2",
     "replace": "^1.1.0",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -33,7 +33,6 @@
     "kleur": "^4.1.5",
     "lodash": "^4.17.21",
     "mergexml": "^1.2.3",
-    "npm-watch": "^0.9.0",
     "plist": "^3.0.4",
     "prettier": "^2.7.1",
     "prompts": "^2.4.2",


### PR DESCRIPTION
`npm-watch` is not used by the project (and would be a dev dependency if it were), so this PR removes it to address vulunerabilties down the line to @capacitor/assets (https://github.com/ionic-team/capacitor-assets/issues/590)